### PR TITLE
docs(readme): fix pull/issues links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is brought to you with ❤️ by [Dominic Elm](https://twitter.com/
 
 # 👷 Want to contribute?
 
-If you want to add a checklist item, file a bug, contribute some code, or improve our documentation, read up on our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md), and check out [open issues](/issues) as well as [open pull requests](/pulls) to avoid potential conflicts.
+If you want to add a checklist item, file a bug, contribute some code, or improve our documentation, read up on our [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md), and check out [open issues](https://github.com/typebytes/angular-checklist/issues) as well as [open pull requests](https://github.com/typebytes/angular-checklist/pulls) to avoid potential conflicts.
 
 # 📄 Licence
 


### PR DESCRIPTION
**Current behavior**
Current relative links to issues and pull pages in the Readme.md don't work as they are relative to the master branch.

**Changes**
relative links changed to absolute links