### PR TITLE
feat(): add note about AOT being default since ng v9

### DIFF
--- a/content/performance/use-aot-compilation.md
+++ b/content/performance/use-aot-compilation.md
@@ -6,7 +6,7 @@ author:
   url: https://twitter.com/mgechev
 ---
 
-**Note**: Starting from Angular v9 AOT compiler is the default one, so if you're on Angular v9+ you need to do nothing.
+**Note**: Starting from Angular v9, the AOT compiler is the default compiler, so if you're using Angular v9+ you don't need to take any action.
 
 # Problem
 

--- a/content/performance/use-aot-compilation.md
+++ b/content/performance/use-aot-compilation.md
@@ -6,6 +6,8 @@ author:
   url: https://twitter.com/mgechev
 ---
 
+**Note**: Starting from Angular v9 AOT compiler is the default one, so if you're on Angular v9+ you need to do nothing.
+
 # Problem
 
 The biggest part of the code that we ship to the browser when we use Angular is the compiler. The compiler is needed to transform our HTML-like templates to Javascript. This is doesn't only has a negative impact on the bundle size but also on the performance as this process is computationally expensive.


### PR DESCRIPTION
Since v9 Angular made AOT the default compiler so, this doesn't apply if your app is running v9+

Instead of removing the file (which was my first approach) I added a note so if someone is using Angular 8 or previous version checks the list.