### PR TITLE
content(performance): don't call functions from the template to get data

### DIFF
--- a/content/performance/dont-call-function-from-template.md
+++ b/content/performance/dont-call-function-from-template.md
@@ -95,7 +95,8 @@ Change Detection strategy describes how Angular should handle Change Detection a
 @Component({
   template: `
     <div>{{ getName() }}</div>
-  `
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MyComponent {
   @Input() id;

--- a/content/performance/dont-call-function-from-template.md
+++ b/content/performance/dont-call-function-from-template.md
@@ -65,7 +65,7 @@ We can address this in a few ways:
 
 ## Assigning values to component properties
 
-Instead of calling a function from the template, we can call it in the component class when needed, and use the value to populate the component property:
+Instead of calling a function from the template, we can call it in the component class when needed, and use the value to populate a component property:
 
 ```typescript
 @Component({
@@ -75,6 +75,7 @@ Instead of calling a function from the template, we can call it in the component
 })
 export class MyComponent {
   name;
+
   private id;
 
   ngOnInit() {
@@ -87,11 +88,11 @@ export class MyComponent {
 }
 ```
 
-That's why Angular will know the exact value of the property all the time, without any cost of checking that on every Change Detection!
+This way it's very deterministic when and how data changes without re-running a function with every change detection cycle.
 
 ## Using OnPush change detection strategy
 
-Change Detection strategy describes how Angular should handle Change Detection and DOM rendering. When using OnPush strategy, the function will be called again only if `@Input` properties changes, or if `@Output` emiters are fired or an `Observable` emits new values.
+The change detection strategy describes how Angular should handle change detection. When using the `OnPush` strategy, change detection only runs if an `@Input` property changes, event are emitted e.g. an `@Output`, or an `Observable` emits new values. Furthermore, change detection can be executed manually via the `ChangeDetectorRef`.
 
 ```typescript
 @Component({

--- a/content/performance/dont-call-function-from-template.md
+++ b/content/performance/dont-call-function-from-template.md
@@ -7,11 +7,11 @@ author:
 
 # Problem
 
-Templates render usually depends on dynamic data generated in component class (async service call, dynamic properties, etc.). Therefore, it's essential to process the data and provide values for the template using component property fields (both regular and Observable) and not use function calls for that purpose. 
+Templates often depend on dynamic data computed in their component classes, e.g. from an async service call, dynamic properties, etc. Therefore, it's essential to process the data and provide values for the template using component properties as opposed to function calls.
 
-Angular can't predict whether value return from the function could change or not, so by default it will perform it once again on every Change Detection check. Potentially in complex components, such functions could be called many times per second, resulting in poor performance.
+Angular can't predict whether the value returned from the function could change or not and by default it will call the function on every change detection cycle. Potentially in complex components, such functions could be called many times per second, resulting in poor performance.
 
-Here is a couple of examples:
+Here are a couple of examples:
 
 ```typescript
 @Component({
@@ -57,13 +57,14 @@ export class MyComponent {
 
 # Solution
 
-We can help Angular with deciding whether value could change or not in a few ways:
+We can address this in a few ways:
 
 - assign values to component properties
-- use OnPush strategy
+- use `OnPush` strategy
 - use custom pipes
 
 ## Assigning values to component properties
+
 Instead of calling a function from the template, we can call it in the component class when needed, and use the value to populate the component property:
 
 ```typescript
@@ -88,7 +89,8 @@ export class MyComponent {
 
 That's why Angular will know the exact value of the property all the time, without any cost of checking that on every Change Detection!
 
-## Using OnPush Change Detection strategy
+## Using OnPush change detection strategy
+
 Change Detection strategy describes how Angular should handle Change Detection and DOM rendering. When using OnPush strategy, the function will be called again only if `@Input` properties changes, or if `@Output` emiters are fired or an `Observable` emits new values.
 
 ```typescript
@@ -108,8 +110,9 @@ export class MyComponent {
 ```
 
 ## Using custom pipes
+
 Pipes by default are pure, which means Angular will execute its `transform` method only on change to the input value.
-Given that example:
+Here's an example:
 
 ```typescript
 @Component({
@@ -121,9 +124,7 @@ export class MyComponent {
   id;
 }
 ```
-
-As long as the `id` property will stay the same, the pipe won't execute its code again and perform a possibly expensive task.
-
+As long as the `id` property doesn't change the pipe won't execute its code again and perform a possibly expensive task.
 
 # Resources
 

--- a/content/performance/dont-call-function-from-template.md
+++ b/content/performance/dont-call-function-from-template.md
@@ -129,5 +129,5 @@ As long as the `id` property doesn't change the pipe won't execute its code agai
 
 # Resources
 
-- ["OnPush strategy"](https://blog.angular-university.io/onpush-change-detection-how-it-works/) - Article about OnPush Change Detection strategys
-- ["Pure pipes"](https://indepth.dev/posts/1061/the-essential-difference-between-pure-and-impure-pipes-in-angular-and-why-that-matters) - Article about pure pipes
+- [Angular OnPush Change Detection and Component Design - Avoid Common Pitfalls](https://blog.angular-university.io/onpush-change-detection-how-it-works/)
+- [The essential difference between pure and impure pipes in Angular and why that matters](https://indepth.dev/posts/1061/the-essential-difference-between-pure-and-impure-pipes-in-angular-and-why-that-matters)

--- a/content/performance/dont-call-function-from-template.md
+++ b/content/performance/dont-call-function-from-template.md
@@ -1,0 +1,130 @@
+---
+title: don't call functions from the template to get data
+author:
+  name: Maciej Wójcik
+  url: https://twitter.com/maciej_wwojcik
+---
+
+# Problem
+
+Templates render usually depends on dynamic data generated in component class (async service call, dynamic properties, etc.). Therefore, it's essential to process the data and provide values for the template using component property fields (both regular and Observable) and not use function calls for that purpose. 
+
+Angular can't predict whether value return from the function could change or not, so by default it will perform it once again on every Change Detection check. Potentially in complex components, such functions could be called many times per second, resulting in poor performance.
+
+Here is a couple of examples:
+
+```typescript
+@Component({
+  template: `
+    <div>{{ getName() }}</div>
+  `
+})
+export class MyComponent {
+  id;
+
+  getName() {
+    return this.service.getName(this.id);
+  }
+}
+```
+
+```typescript
+@Component({
+  template: `
+    <button [disabled]="isDisabled()"></button>
+  `
+})
+export class MyComponent {
+  isDisabled() {
+    return Math.random() > 0.5
+  }
+}
+```
+
+```typescript
+@Component({
+  template: `
+    <li *ngFor="let item of getItems()"></div>
+  `
+})
+export class MyComponent {
+  getItems() {
+    return this.service.getBooks();
+  }
+}
+```
+
+
+# Solution
+
+We can help Angular with deciding whether value could change or not in a few ways:
+
+- assign values to component properties
+- use OnPush strategy
+- use custom pipes
+
+## Assigning values to component properties
+Instead of calling a function from the template, we can call it in the component class when needed, and use the value to populate the component property:
+
+```typescript
+@Component({
+  template: `
+    <div>{{ name }}</div>
+  `
+})
+export class MyComponent {
+  name;
+  private id;
+
+  ngOnInit() {
+    this.name = this.getName();
+  }
+
+  getName() {
+    return this.service.getName(this.id);
+  }
+}
+```
+
+That's why Angular will know the exact value of the property all the time, without any cost of checking that on every Change Detection!
+
+## Using OnPush Change Detection strategy
+Change Detection strategy describes how Angular should handle Change Detection and DOM rendering. When using OnPush strategy, the function will be called again only if `@Input` properties changes, or if `@Output` emiters are fired or an `Observable` emits new values.
+
+```typescript
+@Component({
+  template: `
+    <div>{{ getName() }}</div>
+  `
+})
+export class MyComponent {
+  @Input() id;
+
+  getName() {
+    return this.service.getName(this.id);
+  }
+}
+```
+
+## Using custom pipes
+Pipes by default are pure, which means Angular will execute its `transform` method only on change to the input value.
+Given that example:
+
+```typescript
+@Component({
+  template: `
+    <div>{{ id | getName }}</div>
+  `
+})
+export class MyComponent {
+  id;
+}
+```
+
+As long as the `id` property will stay the same, the pipe won't execute its code again and perform a possibly expensive task.
+
+
+# Resources
+
+- ["OnPush strategy"](https://blog.angular-university.io/onpush-change-detection-how-it-works/) - Article about OnPush Change Detection strategys
+- ["Pure pipes"](https://indepth.dev/posts/1061/the-essential-difference-between-pure-and-impure-pipes-in-angular-and-why-that-matters) - Article about pure pipes


### PR DESCRIPTION
Add new content in the performance category about performance issues as a result of calling functions directly from the template