### PR TITLE
fix: typos in General section & add note about migrations

### DIFF
--- a/content/general/use-latest-version-of-everything.md
+++ b/content/general/use-latest-version-of-everything.md
@@ -11,7 +11,7 @@ The Angular team and community are continually improving the ecosystem to make i
 
 Angular uses semantic versioning (semver), which means they use a regular schedule of releases. This includes a major release every six months, 1-3 minor releases for each major release, and a patch release almost every week. It’s important to keep up with major releases, as they contain significant new features. The longer we wait to update our application, the more expensive a future update can be. **Be aware** that major releases may contain breaking changes.
 
-In addition, when APIs are deprecated, they remain present in the next two major releases until they are removed. Again, if we wait too long, it’s likely that the update will require much more work. You can read more about deprecations in the changelog.
+In addition, when APIs are deprecated, they remain present in the next two major releases until they are removed. Again, if we wait too long, it’s likely that an update will require much more work. You can read more about deprecations in the changelog.
 
 **Note:** In the case of significant refactors, the Angular team may create schematics that can help update your app for you. At present, there are [schematics] (https://angular.dev/reference/migrations) that convert to standalone components, the new control flow syntax, and more.
 

--- a/content/general/use-latest-version-of-everything.md
+++ b/content/general/use-latest-version-of-everything.md
@@ -7,11 +7,13 @@ author:
 
 # Problem 
 
-The Angular team and community are continually improving the ecosystem to make it easier to build applications. Both the performance and the compiler (e.g Ivy Renderer) are constantly being improved for better web applications. 
+The Angular team and community are continually improving the ecosystem to make it easier to build applications. Both the performance and the compiler (e.g., Ivy Renderer) are constantly being improved for better web applications.
 
-Angular uses semantic versioning (semver) which means they use a regular schedule of releases. This includes a major release every six month, 1-3 minor releases for each major release, and a patch release almost every week. It's important to keep up with major releases as they contain significant new features. The longer we wait to update our application, the more expensive will be a future update. Be aware, that major releases may contain breaking changes.   
+Angular uses semantic versioning (semver), which means they use a regular schedule of releases. This includes a major release every six months, 1-3 minor releases for each major release, and a patch release almost every week. It’s important to keep up with major releases, as they contain significant new features. The longer we wait to update our application, the more expensive a future update can be. **Be aware** that major releases may contain breaking changes.
 
-In addition, when API's get deprecated they remain present in the next two major releases until they are removed. Again, if we wait to long, it's likely that the update requires much more work. You can read more about deprecations in the [changelog](https://github.com/angular/angular/blob/master/CHANGELOG.md).
+In addition, when APIs are deprecated, they remain present in the next two major releases until they are removed. Again, if we wait too long, it’s likely that the update will require much more work. You can read more about deprecations in the changelog.
+
+**Note:** In the case of significant refactors, the Angular team may create schematics that can help update your app for you. At present, there are [schematics] (https://angular.dev/reference/migrations) that convert to standalone components, the new control flow syntax, and more.
 
 # Solution
 


### PR DESCRIPTION
Fixed some typos and general word flow.  

Added a note about migrations.  Possible to add a separate Todo item for migrations.  Separate migrations can help fill out the General section.   